### PR TITLE
FEAT: Implement user profile CRUD with JWT authentication and authorization

### DIFF
--- a/JobPortalAPI/Controllers/AuthController.cs
+++ b/JobPortalAPI/Controllers/AuthController.cs
@@ -12,7 +12,7 @@ namespace JobPortalAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class AuthController : Controller
+    public class AuthController : ControllerBase
     {
         private readonly ApplicationDbContext _db;
         private readonly IPasswordHasher<User> _hasher;

--- a/JobPortalAPI/Controllers/AuthController.cs
+++ b/JobPortalAPI/Controllers/AuthController.cs
@@ -29,17 +29,38 @@ namespace JobPortalAPI.Controllers
         public async Task<IActionResult> Register(RegisterDto dto)
         {
             if (await _db.Users.AnyAsync(u => u.Email == dto.Email))
-                return BadRequest("This email is on the list");
+                return BadRequest("Email already registered");
 
             var user = new User
             {
-                FullName = dto.FullName,
+                FirstName = dto.FirstName,
+                LastName = dto.LastName,
                 Email = dto.Email,
-                Role = dto.Role ?? "User"
+                Role = dto.Role ?? "User",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
             };
 
             user.PasswordHash = _hasher.HashPassword(user, dto.Password);
+
             await _db.Users.AddAsync(user);
+            await _db.SaveChangesAsync();
+
+            var profile = new UserProfile
+            {
+                UserId = user.Id,
+                FirstName = dto.FirstName,
+                LastName = dto.LastName,
+                PhoneNumber = null,
+                Address = null,
+                Bio = null,
+                ProfilePictureUrl = null,
+                Location = null,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            await _db.UserProfiles.AddAsync(profile);
             await _db.SaveChangesAsync();
 
             var token = _jwt.GenerateToken(user);

--- a/JobPortalAPI/Controllers/UserProfileController.cs
+++ b/JobPortalAPI/Controllers/UserProfileController.cs
@@ -1,0 +1,93 @@
+﻿using System.Security.Claims;
+using JobPortalAPI.Data;
+using JobPortalAPI.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace JobPortalAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class UserProfileController : ControllerBase
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public UserProfileController(ApplicationDbContext db, IHttpContextAccessor httpContextAccessor)
+        {
+            _db = db;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetProfile()
+        {
+            int userId = GetUserId();
+            var profile = await _db.UserProfiles.FirstOrDefaultAsync(p => p.UserId == userId);
+
+            if (profile == null)
+            {
+                return NotFound("Profile not found.");
+            }
+
+            var dto = new UserProfileDto
+            {
+                FirstName = profile.FirstName,
+                LastName = profile.LastName,
+                PhoneNumber = profile.PhoneNumber,
+                Address = profile.Address,
+                Bio = profile.Bio,
+                ProfilePictureUrl = profile.ProfilePictureUrl,
+                Location = profile.Location
+            };
+
+            return Ok(dto);
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> UpdateProfile(UserProfileDto dto)
+        {
+            int userId = GetUserId();
+            var profile = await _db.UserProfiles.FirstOrDefaultAsync(p => 
+                p.UserId == userId);
+            
+            if (profile == null)
+                return NotFound("Profile not found.");
+            
+            profile.FirstName = dto.FirstName;
+            profile.LastName = dto.LastName;
+            profile.PhoneNumber = dto.PhoneNumber;
+            profile.Address = dto.Address;
+            profile.Bio = dto.Bio;
+            profile.ProfilePictureUrl = dto.ProfilePictureUrl;
+            profile.Location = dto.Location;
+            profile.UpdatedAt = DateTime.UtcNow;
+
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete]
+        public async Task<IActionResult> DeleteProfile()
+        {
+            int userId = GetUserId();
+            var profile = await _db.UserProfiles.FirstOrDefaultAsync(p => 
+                p.UserId == userId);
+            
+            if (profile == null)
+                return NotFound("Profile not found.");
+            
+            _db.UserProfiles.Remove(profile);
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+
+        private int GetUserId()
+        {
+            var userIdClaim = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier);
+            return userIdClaim != null ? int.Parse(userIdClaim.Value) : 0;
+        }
+    }
+}

--- a/JobPortalAPI/DTOs/RegisterDto.cs
+++ b/JobPortalAPI/DTOs/RegisterDto.cs
@@ -2,7 +2,8 @@
 {
     public class RegisterDto
     {
-        public string FullName { get; set; } = null!;
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
         public string Email { get; set; } = null!;
         public string Password { get; set; } = null!;
         public string Role { get; set; } = "User"; 

--- a/JobPortalAPI/DTOs/UserProfileDto.cs
+++ b/JobPortalAPI/DTOs/UserProfileDto.cs
@@ -1,0 +1,13 @@
+﻿namespace JobPortalAPI.DTOs
+{
+    public class UserProfileDto
+    {
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? PhoneNumber { get; set; }
+        public string? Address { get; set; }
+        public string? Bio { get; set; }
+        public string? ProfilePictureUrl { get; set; }
+        public string? Location { get; set; }
+    }
+}

--- a/JobPortalAPI/Data/ApplicationDbContext.cs
+++ b/JobPortalAPI/Data/ApplicationDbContext.cs
@@ -5,11 +5,20 @@ namespace JobPortalAPI.Data
 {
     public class ApplicationDbContext : DbContext
     {
-        public ApplicationDbContext(DbContextOptions options)
-            : base(options)
+        public DbSet<User> Users { get; set; }
+        public DbSet<UserProfile> UserProfiles { get; set; }
+
+        public ApplicationDbContext(DbContextOptions options) 
+            : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<User>()
+                .HasOne(u => u.Profile)
+                .WithOne(p => p.User)
+                .HasForeignKey<UserProfile>(p => p.UserId);
         }
-       
-        public DbSet<User> Users { get; set; } = null!;
     }
 }

--- a/JobPortalAPI/Migrations/20250525080947_AddUserProfileRelation.Designer.cs
+++ b/JobPortalAPI/Migrations/20250525080947_AddUserProfileRelation.Designer.cs
@@ -4,6 +4,7 @@ using JobPortalAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JobPortalAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250525080947_AddUserProfileRelation")]
+    partial class AddUserProfileRelation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JobPortalAPI/Migrations/20250525080947_AddUserProfileRelation.cs
+++ b/JobPortalAPI/Migrations/20250525080947_AddUserProfileRelation.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobPortalAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserProfileRelation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "FullName",
+                table: "Users",
+                newName: "LastName");
+
+            migrationBuilder.AddColumn<string>(
+                name: "FirstName",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Users",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.CreateTable(
+                name: "UserProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    FirstName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    LastName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Bio = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ProfilePictureUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Location = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_UserId",
+                table: "UserProfiles",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "FirstName",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Users");
+
+            migrationBuilder.RenameColumn(
+                name: "LastName",
+                table: "Users",
+                newName: "FullName");
+        }
+    }
+}

--- a/JobPortalAPI/Models/User.cs
+++ b/JobPortalAPI/Models/User.cs
@@ -3,10 +3,14 @@
     public class User
     {
         public int Id { get; set; }
-        public string? FullName { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
         public string? Email { get; set; }
         public string? PasswordHash { get; set; } 
         public string Role { get; set; } = "User";
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        public UserProfile? Profile { get; set; }
     }
 }

--- a/JobPortalAPI/Models/UserProfile.cs
+++ b/JobPortalAPI/Models/UserProfile.cs
@@ -1,0 +1,20 @@
+﻿namespace JobPortalAPI.Models
+{
+    public class UserProfile
+    {
+        public int Id { get; set; }
+
+        public int UserId { get; set; }
+        public User User { get; set; } = null!;
+        
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? PhoneNumber { get; set; }
+        public string? Address { get; set; }
+        public string? Bio { get; set; }
+        public string? ProfilePictureUrl { get; set; }
+        public string? Location { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/JobPortalAPI/Program.cs
+++ b/JobPortalAPI/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddSwaggerGen(c =>

--- a/JobPortalAPI/Services/JwtService.cs
+++ b/JobPortalAPI/Services/JwtService.cs
@@ -19,7 +19,7 @@ namespace JobPortalAPI.Services
             var claims = new[]
             {
                 new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
-                new Claim(ClaimTypes.Name, user.FullName!),
+                new Claim(ClaimTypes.Name, $"{user.FirstName} {user.LastName}"),
                 new Claim(ClaimTypes.Email, user.Email!),
                 new Claim(ClaimTypes.Role, user.Role)
             };


### PR DESCRIPTION
This PR adds full CRUD operations for user profiles:

- GET /api/UserProfile — fetch authenticated user's profile  
- PUT /api/UserProfile — update authenticated user's profile  
- DELETE /api/UserProfile — delete authenticated user's profile  

Additional features included:  
- JWT-based user identification to secure endpoints  
- [Authorize] attribute applied to all profile endpoints  
- Swagger configured for testing with JWT authentication  
- Created UserProfileDto for data transfer  
- Proper one-to-one relationship between User and UserProfile models  

All endpoints tested and verified working as expected.
