### PR TITLE
Feature: Resume upload and download service implementation

### DIFF
--- a/JobPortalAPI/Program.cs
+++ b/JobPortalAPI/Program.cs
@@ -3,9 +3,14 @@ using JobPortalAPI.Data;
 using JobPortalAPI.Models;
 using JobPortalAPI.Services;
 using Microsoft.OpenApi.Models; 
-using Microsoft.EntityFrameworkCore;
+using JobPortalAPI.Services.Job;
+using JobPortalAPI.Services.Auth;
+using JobPortalAPI.Services.Admin;
+using JobPortalAPI.Services.Resume;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using JobPortalAPI.Services.Application;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -50,6 +55,11 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 
 builder.Services.AddScoped<JwtService>();
 builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
+builder.Services.AddScoped<IAdminService, AdminService>();
+builder.Services.AddScoped<IApplicationService, ApplicationService>();
+builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IJobService, JobService>();
+builder.Services.AddScoped<IResumeService, ResumeService>();
 
 builder.Services.AddAuthentication(options =>
 {

--- a/JobPortalAPI/Services/Resume/IResumeService.cs
+++ b/JobPortalAPI/Services/Resume/IResumeService.cs
@@ -1,0 +1,8 @@
+﻿namespace JobPortalAPI.Services.Resume
+{
+    public interface IResumeService
+    {
+        Task<string> UploadResumeAsync(IFormFile file, int userId);
+        Task<(byte[] fileContent, string contentType, string fileName)?> GetResumeAsync(int userId);
+    }
+}

--- a/JobPortalAPI/Services/Resume/ResumeService.cs
+++ b/JobPortalAPI/Services/Resume/ResumeService.cs
@@ -1,0 +1,65 @@
+﻿namespace JobPortalAPI.Services.Resume
+{
+    public class ResumeService : IResumeService
+    {
+        private readonly IWebHostEnvironment _env;
+
+        public ResumeService(IWebHostEnvironment env)
+        {
+            _env = env;
+        }
+
+        public async Task<string> UploadResumeAsync(IFormFile file, int userId)
+        {
+            if (file == null || file.Length == 0)
+                throw new ArgumentException("File is empty.");
+
+            var extension = Path.GetExtension(file.FileName);
+            var allowedExtensions = new[] { ".pdf", ".docx" };
+            if (!allowedExtensions.Contains(extension.ToLower()))
+                throw new ArgumentException("Unsupported file type.");
+
+            var fileName = $"resume_{userId}{extension}";
+            var savePath = Path.Combine(_env.WebRootPath, "resumes");
+
+            if (!Directory.Exists(savePath))
+                Directory.CreateDirectory(savePath);
+
+            var filePath = Path.Combine(savePath, fileName);
+
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            return $"/resumes/{fileName}";
+        }
+
+        public async Task<(byte[] fileContent, string contentType, string fileName)?> GetResumeAsync(int userId)
+        {
+            var resumeFolder = Path.Combine(_env.WebRootPath, "resumes");
+            if (!Directory.Exists(resumeFolder))
+                return null;
+
+            var files = Directory.GetFiles(resumeFolder, $"resume_{userId}.*");
+            var filePath = files.FirstOrDefault();
+
+            if (filePath == null)
+                return null;
+
+            var fileContent = await File.ReadAllBytesAsync(filePath);
+            var extension = Path.GetExtension(filePath).ToLower();
+
+            var contentType = extension switch
+            {
+                ".pdf" => "application/pdf",
+                ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                _ => "application/octet-stream"
+            };
+
+            var fileName = Path.GetFileName(filePath);
+
+            return (fileContent, contentType, fileName);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the Resume service which allows users to upload their resumes and retrieve them later.

- POST /api/resume/upload: Upload a resume file (PDF or DOCX).
- GET /api/resume: Download the logged-in user's resume.
- Stores resumes in wwwroot/resumes folder with user-specific naming.

Access restricted to users with the Role.User role.
